### PR TITLE
Remove `start_url` from manifest.json to improve usage when adding the PWA to a users' home screen

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -8,7 +8,6 @@
       "type": "image/x-icon"
     }
   ],
-  "start_url": ".",
   "display": "standalone",
   "theme_color": "#000000",
   "background_color": "#ffffff"


### PR DESCRIPTION
Hi everyone! 

I got to use this web client as it's currently hosted on client.rabbitcontrol.cc recently in a location that uses this to remotely control a media server. It's quite handy in general, especially when using the "add to home screen" feature in iOS for quick access. However it's a bit cumbersome to always remember and enter the remote IP address. Reading the code I found out that one can initiate a connection automatically by following the scheme of i.e. `client.local/#192.168.1.103:10000`. However, this special URL cannot (so far) be used as a starting point for that "locally saved" PWA – the part after the domain is always being cut off since the `start_url` in `manifest.json` is defined to `.`.

I suggest to change this and remove that setting from the manifest entirely. This allows using an URL as above when using "add to home screen" in iOS, so that opening that bookmark from ones home screen would directly initiate a connection to a controlled entity. According to https://www.w3.org/TR/appmanifest/#dfn-start_url it's not a required property either. However I did not test this change on an Android device (for the lack of such a device...).

Please let me know what you think of this change and if you consider/accept pull requests in general (I'm not entirely sure of your organisation's structure and if that change would ever show up in client.rabbitcontrol.cc ;-) ). I could also imagine of coming up with a "store connection settings" feature within this client in the future – would you consider accepting such a bigger change as well?

Best,
Benjamin.